### PR TITLE
chore: set search_path to public in SQL functions for consistency

### DIFF
--- a/supabase/characters.sql
+++ b/supabase/characters.sql
@@ -45,6 +45,7 @@ CREATE OR REPLACE FUNCTION admin_delete_character(character_id UUID)
 RETURNS VOID
 LANGUAGE plpgsql
 SECURITY DEFINER -- This makes the function run with the privileges of the owner
+SET search_path = public
 AS $$
 BEGIN
   DELETE FROM characters WHERE id = character_id;

--- a/supabase/leaderboard.sql
+++ b/supabase/leaderboard.sql
@@ -81,6 +81,7 @@ GRANT EXECUTE ON FUNCTION update_leaderboard TO service_role;
 CREATE OR REPLACE FUNCTION public.handle_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SET search_path = public
 AS $$
 BEGIN
     NEW.updated_at = timezone('utc'::text, now());


### PR DESCRIPTION
- Updated the `admin_delete_character` and `handle_updated_at` functions to include `SET search_path = public`, ensuring that the functions operate within the correct schema context.

- [x] Test with db changes